### PR TITLE
Cortana sample

### DIFF
--- a/Scenarios/Cortana/CortanaSample.xcodeproj/project.pbxproj
+++ b/Scenarios/Cortana/CortanaSample.xcodeproj/project.pbxproj
@@ -1,0 +1,307 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		777D9A7E1CE6673800AB84C9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 777D9A7D1CE6673800AB84C9 /* main.m */; };
+		777D9A811CE6673800AB84C9 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 777D9A801CE6673800AB84C9 /* AppDelegate.m */; };
+		777D9A841CE6673800AB84C9 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 777D9A831CE6673800AB84C9 /* ViewController.m */; };
+		777D9A871CE6673800AB84C9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 777D9A851CE6673800AB84C9 /* Main.storyboard */; };
+		777D9A891CE6673800AB84C9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 777D9A881CE6673800AB84C9 /* Assets.xcassets */; };
+		777D9A8C1CE6673800AB84C9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 777D9A8A1CE6673800AB84C9 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		777D9A791CE6673800AB84C9 /* CortanaSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CortanaSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		777D9A7D1CE6673800AB84C9 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		777D9A7F1CE6673800AB84C9 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		777D9A801CE6673800AB84C9 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		777D9A821CE6673800AB84C9 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		777D9A831CE6673800AB84C9 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		777D9A861CE6673800AB84C9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		777D9A881CE6673800AB84C9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		777D9A8B1CE6673800AB84C9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		777D9A8D1CE6673800AB84C9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		777D9A761CE6673800AB84C9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		777D9A701CE6673800AB84C9 = {
+			isa = PBXGroup;
+			children = (
+				777D9A7B1CE6673800AB84C9 /* CortanaSample */,
+				777D9A7A1CE6673800AB84C9 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		777D9A7A1CE6673800AB84C9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				777D9A791CE6673800AB84C9 /* CortanaSample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		777D9A7B1CE6673800AB84C9 /* CortanaSample */ = {
+			isa = PBXGroup;
+			children = (
+				777D9A7F1CE6673800AB84C9 /* AppDelegate.h */,
+				777D9A801CE6673800AB84C9 /* AppDelegate.m */,
+				777D9A821CE6673800AB84C9 /* ViewController.h */,
+				777D9A831CE6673800AB84C9 /* ViewController.m */,
+				777D9A851CE6673800AB84C9 /* Main.storyboard */,
+				777D9A881CE6673800AB84C9 /* Assets.xcassets */,
+				777D9A8A1CE6673800AB84C9 /* LaunchScreen.storyboard */,
+				777D9A8D1CE6673800AB84C9 /* Info.plist */,
+				777D9A7C1CE6673800AB84C9 /* Supporting Files */,
+			);
+			path = CortanaSample;
+			sourceTree = "<group>";
+		};
+		777D9A7C1CE6673800AB84C9 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				777D9A7D1CE6673800AB84C9 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		777D9A781CE6673800AB84C9 /* CortanaSample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 777D9A901CE6673800AB84C9 /* Build configuration list for PBXNativeTarget "CortanaSample" */;
+			buildPhases = (
+				777D9A751CE6673800AB84C9 /* Sources */,
+				777D9A761CE6673800AB84C9 /* Frameworks */,
+				777D9A771CE6673800AB84C9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CortanaSample;
+			productName = CortanaSample;
+			productReference = 777D9A791CE6673800AB84C9 /* CortanaSample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		777D9A711CE6673800AB84C9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = Microsoft;
+				TargetAttributes = {
+					777D9A781CE6673800AB84C9 = {
+						CreatedOnToolsVersion = 7.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 777D9A741CE6673800AB84C9 /* Build configuration list for PBXProject "CortanaSample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 777D9A701CE6673800AB84C9;
+			productRefGroup = 777D9A7A1CE6673800AB84C9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				777D9A781CE6673800AB84C9 /* CortanaSample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		777D9A771CE6673800AB84C9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				777D9A8C1CE6673800AB84C9 /* LaunchScreen.storyboard in Resources */,
+				777D9A891CE6673800AB84C9 /* Assets.xcassets in Resources */,
+				777D9A871CE6673800AB84C9 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		777D9A751CE6673800AB84C9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				777D9A841CE6673800AB84C9 /* ViewController.m in Sources */,
+				777D9A811CE6673800AB84C9 /* AppDelegate.m in Sources */,
+				777D9A7E1CE6673800AB84C9 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		777D9A851CE6673800AB84C9 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				777D9A861CE6673800AB84C9 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		777D9A8A1CE6673800AB84C9 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				777D9A8B1CE6673800AB84C9 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		777D9A8E1CE6673800AB84C9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		777D9A8F1CE6673800AB84C9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		777D9A911CE6673800AB84C9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = CortanaSample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = Microsoft.CortanaSample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		777D9A921CE6673800AB84C9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = CortanaSample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = Microsoft.CortanaSample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		777D9A741CE6673800AB84C9 /* Build configuration list for PBXProject "CortanaSample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				777D9A8E1CE6673800AB84C9 /* Debug */,
+				777D9A8F1CE6673800AB84C9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		777D9A901CE6673800AB84C9 /* Build configuration list for PBXNativeTarget "CortanaSample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				777D9A911CE6673800AB84C9 /* Debug */,
+				777D9A921CE6673800AB84C9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 777D9A711CE6673800AB84C9 /* Project object */;
+}

--- a/Scenarios/Cortana/CortanaSample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Scenarios/Cortana/CortanaSample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:CortanaSample.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Scenarios/Cortana/CortanaSample/AppDelegate.h
+++ b/Scenarios/Cortana/CortanaSample/AppDelegate.h
@@ -1,17 +1,29 @@
+//******************************************************************************
 //
-//  AppDelegate.h
-//  CortanaSample
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 //
-//  Created by Phil Nachreiner on 5/13/16.
-//  Copyright © 2016 Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+//////////////////////////////////////
+// WinObjC Sample - Cortana //////////
+// github.com/Microsoft/WinObjC //////
+//////////////////////////////////////
 
 #import <UIKit/UIKit.h>
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
-
 
 @end
 

--- a/Scenarios/Cortana/CortanaSample/AppDelegate.h
+++ b/Scenarios/Cortana/CortanaSample/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  CortanaSample
+//
+//  Created by Phil Nachreiner on 5/13/16.
+//  Copyright © 2016 Microsoft. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/Scenarios/Cortana/CortanaSample/AppDelegate.m
+++ b/Scenarios/Cortana/CortanaSample/AppDelegate.m
@@ -67,14 +67,14 @@
 	WSStorageFolder *installedLocation = package.installedLocation;
 
 	// Load VCD XML file describing voice commands from app installation location
-	[installedLocation getFileAsync:@"CortanaSampleCommands.xml" 
-									success:^(WSStorageFile *storageFile) {
-										// install commands
-										[WAVVoiceCommandDefinitionManager installCommandDefinitionsFromStorageFileAsync:storageFile];
-									} 
-									failure:^(NSError *error) {
-										NSLog(@"Failed to load commands file: %@", error);
-									}];
+	[installedLocation getFileAsync:@"CortanaSampleCommands.xml"
+                            success:^(WSStorageFile *storageFile) {
+                                // Install commands
+                                [WAVVoiceCommandDefinitionManager installCommandDefinitionsFromStorageFileAsync:storageFile];
+                            }
+                            failure:^(NSError *error) {
+                                NSLog(@"Failed to load commands file: %@", error);
+                            }];
     
     // Handle activation-by-voice command
     if (launchOptions != nil) {

--- a/Scenarios/Cortana/CortanaSample/AppDelegate.m
+++ b/Scenarios/Cortana/CortanaSample/AppDelegate.m
@@ -1,0 +1,93 @@
+//
+//  AppDelegate.m
+//  CortanaSample
+//
+//  Created by Phil Nachreiner on 5/13/16.
+//  Copyright © 2016 Microsoft. All rights reserved.
+//
+
+#import "AppDelegate.h"
+#import "ViewController.h"
+
+
+#ifdef WINOBJC
+#import <UWP/WindowsApplicationModel.h>
+#import <UWP/WindowsStorage.h>
+#import <UWP/WindowsApplicationModelVoiceCommands.h>
+#endif
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+	if(launchOptions != nil){
+#ifdef WINOBJC
+		if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
+			// you could handle WMSSpeechRecognitionResult in here also
+		}
+#endif
+	}
+	return YES;
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+#ifdef WINOBJC
+	WAPackage *package = [WAPackage current];
+	WSStorageFolder *installedLocation = package.installedLocation;
+
+	// load command file from app installation location
+	[installedLocation getFileAsync:@"CortanaSampleCommands.xml" 
+									success:^(WSStorageFile *storageFile) {
+										// install commands
+										[WAVVoiceCommandDefinitionManager installCommandDefinitionsFromStorageFileAsync:storageFile];
+									} 
+									failure:^(NSError *error) {
+										NSLog(@"Failed to load commands file: %@", error);
+									}];
+
+    if (launchOptions != nil) {
+		// check for the key containing WMSSpeechRecognitionResults 
+		if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
+			WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
+			ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
+			[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
+		}
+	}
+#endif
+	return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+#ifdef WINOBJC
+// Called when a voice command is received.
+- (void)application:(UIApplication *)application didReceiveVoiceCommand:(WMSSpeechRecognitionResult*)result {
+	ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
+	[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
+}
+#endif
+
+@end

--- a/Scenarios/Cortana/CortanaSample/AppDelegate.m
+++ b/Scenarios/Cortana/CortanaSample/AppDelegate.m
@@ -1,14 +1,26 @@
+//******************************************************************************
 //
-//  AppDelegate.m
-//  CortanaSample
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 //
-//  Created by Phil Nachreiner on 5/13/16.
-//  Copyright © 2016 Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+//////////////////////////////////////
+// WinObjC Sample - Cortana //////////
+// github.com/Microsoft/WinObjC //////
+//////////////////////////////////////
 
 #import "AppDelegate.h"
 #import "ViewController.h"
-
 
 #ifdef WINOBJC
 #import <UWP/WindowsApplicationModel.h>
@@ -20,25 +32,41 @@
 
 @end
 
+#ifdef WINOBJC
+// Tell the WinObjC runtime the application size
+@implementation UIApplication (UIApplicationInitialStartupMode)
++ (void)setStartupDisplayMode:(WOCDisplayMode*)mode {
+    mode.autoMagnification = TRUE;
+    mode.sizeUIWindowToFit = TRUE;
+    mode.clampScaleToClosestExpected = FALSE;
+    mode.fixedWidth = 0;
+    mode.fixedHeight = 0;
+    mode.magnification = 1.0;
+}
+@end
+#endif
+
 @implementation AppDelegate
 
-- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
 	if(launchOptions != nil){
 #ifdef WINOBJC
 		if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
-			// you could handle WMSSpeechRecognitionResult in here also
+			// You could handle WMSSpeechRecognitionResult in here also
 		}
 #endif
 	}
 	return YES;
 }
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
 #ifdef WINOBJC
 	WAPackage *package = [WAPackage current];
 	WSStorageFolder *installedLocation = package.installedLocation;
 
-	// load command file from app installation location
+	// Load VCD XML file describing voice commands from app installation location
 	[installedLocation getFileAsync:@"CortanaSampleCommands.xml" 
 									success:^(WSStorageFile *storageFile) {
 										// install commands
@@ -47,9 +75,10 @@
 									failure:^(NSError *error) {
 										NSLog(@"Failed to load commands file: %@", error);
 									}];
-
+    
+    // Handle activation-by-voice command
     if (launchOptions != nil) {
-		// check for the key containing WMSSpeechRecognitionResults 
+		// Check for the key containing WMSSpeechRecognitionResults
 		if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
 			WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
 			ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
@@ -60,34 +89,38 @@
 	return YES;
 }
 
-- (void)applicationWillResignActive:(UIApplication *)application {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-}
-
-- (void)applicationDidEnterBackground:(UIApplication *)application {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-}
-
-- (void)applicationWillEnterForeground:(UIApplication *)application {
-    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-}
-
-- (void)applicationDidBecomeActive:(UIApplication *)application {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-}
-
-- (void)applicationWillTerminate:(UIApplication *)application {
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-}
-
 #ifdef WINOBJC
-// Called when a voice command is received.
-- (void)application:(UIApplication *)application didReceiveVoiceCommand:(WMSSpeechRecognitionResult*)result {
-	ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
-	[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
+// Called when a voice command is received
+- (void)application:(UIApplication *)application didReceiveVoiceCommand:(WMSSpeechRecognitionResult*)result
+{
+    ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
+    [viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
 }
 #endif
+
+- (void)applicationWillResignActive:(UIApplication *)application
+{
+    
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+    
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+{
+    
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application
+{
+    
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{
+    
+}
 
 @end

--- a/Scenarios/Cortana/CortanaSample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Scenarios/Cortana/CortanaSample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Scenarios/Cortana/CortanaSample/Base.lproj/LaunchScreen.storyboard
+++ b/Scenarios/Cortana/CortanaSample/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Scenarios/Cortana/CortanaSample/Base.lproj/Main.storyboard
+++ b/Scenarios/Cortana/CortanaSample/Base.lproj/Main.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1713" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Scenarios/Cortana/CortanaSample/CortanaSampleCommands.xml
+++ b/Scenarios/Cortana/CortanaSample/CortanaSampleCommands.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VoiceCommands xmlns="http://schemas.microsoft.com/voicecommands/1.2">
+  <CommandSet xml:lang="en-us" Name="CortanaSampleCommandSet_en-us">
+    <AppName>Cortana Sample</AppName>
+    <Example>Show trip to London</Example>
+
+    <Command Name="showTripToDestination">
+      <Example>Show trip to London</Example>
+      <ListenFor RequireAppName="BeforeOrAfterPhrase">show [my] trip to {destination}</ListenFor>
+      <ListenFor RequireAppName="ExplicitlySpecified">show [my] {builtin:AppName} trip to {destination}</ListenFor>
+      <Feedback>Showing trip to {destination}</Feedback>
+      <Navigate />
+    </Command>
+    <PhraseList Label="destination">
+      <Item>London</Item>
+      <Item>Long Island</Item>
+      <Item>Melbourne</Item>
+      <Item>North Dakota</Item>
+      <Item>Rio</Item>
+      <Item>Yosemite National Park</Item>
+    </PhraseList>
+  </CommandSet>
+</VoiceCommands>

--- a/Scenarios/Cortana/CortanaSample/Info.plist
+++ b/Scenarios/Cortana/CortanaSample/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Scenarios/Cortana/CortanaSample/ViewController.h
+++ b/Scenarios/Cortana/CortanaSample/ViewController.h
@@ -15,7 +15,7 @@
 //******************************************************************************
 
 //////////////////////////////////////
-// WinObjC Sample - Live Tiles ///////
+// WinObjC Sample - Cortana //////////
 // github.com/Microsoft/WinObjC //////
 //////////////////////////////////////
 
@@ -30,7 +30,7 @@
 - (void)voiceCommand: (NSString*)text;
 - (void)textSpoken: (NSString*)text;
 - (void)semanticInterpretation: (NSString*)text;
-- (void)launchedBy : (NSString*)text;
+- (void)launchedBy: (NSString*)text;
 
 #ifdef WINOBJC
 - (void)setSpeechRecognitionLabelsWithSpeechRecognitionResult: (WMSSpeechRecognitionResult*)result;

--- a/Scenarios/Cortana/CortanaSample/ViewController.h
+++ b/Scenarios/Cortana/CortanaSample/ViewController.h
@@ -1,0 +1,39 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+//////////////////////////////////////
+// WinObjC Sample - Live Tiles ///////
+// github.com/Microsoft/WinObjC //////
+//////////////////////////////////////
+
+#import <UIKit/UIKit.h>
+
+#ifdef WINOBJC
+#import <UWP/WindowsApplicationModelVoiceCommands.h>
+#endif
+
+@interface ViewController : UIViewController
+
+- (void)voiceCommand: (NSString*)text;
+- (void)textSpoken: (NSString*)text;
+- (void)semanticInterpretation: (NSString*)text;
+- (void)launchedBy : (NSString*)text;
+
+#ifdef WINOBJC
+- (void)setSpeechRecognitionLabelsWithSpeechRecognitionResult: (WMSSpeechRecognitionResult*)result;
+#endif
+
+@end

--- a/Scenarios/Cortana/CortanaSample/ViewController.m
+++ b/Scenarios/Cortana/CortanaSample/ViewController.m
@@ -15,7 +15,7 @@
 //******************************************************************************
 
 //////////////////////////////////////
-// WinObjC Sample - Cortana    ///////
+// WinObjC Sample - Cortana //////////
 // github.com/Microsoft/WinObjC //////
 //////////////////////////////////////
 
@@ -46,7 +46,7 @@ static NSString * kInfoString = @"This WinObjC sample project demonstrates how t
 static NSString * kLabelVoiceCommandInitialText = @"VOICECOMMAND";
 static NSString * kLabelTextSpokenInitialText = @"TEXTSPOKEN";
 static NSString * kLabelDestinationInitialText = @"DESTINATION";
-static NSString * klabelCommandModeText = @"COMMANDMODE";
+static NSString * kLabelCommandModeText = @"COMMANDMODE";
 
 - (void) viewDidLoad
 {
@@ -94,7 +94,7 @@ static NSString * klabelCommandModeText = @"COMMANDMODE";
     self.labelDestination.translatesAutoresizingMaskIntoConstraints = NO;
 
 	self.labelCommandMode = [UILabel new];
-    self.labelCommandMode.text = klabelCommandModeText;
+    self.labelCommandMode.text = kLabelCommandModeText;
     self.labelCommandMode.font = [UIFont systemFontOfSize:[UIFont smallSystemFontSize]];
     self.labelCommandMode.numberOfLines = 0;
     self.labelCommandMode.lineBreakMode = NSLineBreakByWordWrapping;
@@ -157,42 +157,46 @@ static NSString * klabelCommandModeText = @"COMMANDMODE";
     return YES;
 }
 
-- (void)voiceCommand: (NSString*)text{
+- (void)voiceCommand: (NSString*)text
+{
 	kLabelVoiceCommandInitialText = text;
     self.labelVoiceCommand.text = kLabelVoiceCommandInitialText;
 }
 
-- (void)textSpoken: (NSString*)text{
+- (void)textSpoken: (NSString*)text
+{
 	kLabelTextSpokenInitialText = text;
     self.labelTextSpoken.text = kLabelTextSpokenInitialText;
 }
 
-- (void)launchedBy: (NSString*)text{
-	klabelCommandModeText = text;
-	self.labelCommandMode.text = klabelCommandModeText;
+- (void)launchedBy: (NSString*)text
+{
+	kLabelCommandModeText = text;
+	self.labelCommandMode.text = kLabelCommandModeText;
 }
 
-- (void)semanticInterpretation: (NSString*)text{
+- (void)semanticInterpretation: (NSString*)text
+{
 	kLabelDestinationInitialText = text;
 	self.labelDestination.text = kLabelDestinationInitialText;
 }
 
 #ifdef WINOBJC
-- (void)setSpeechRecognitionLabelsWithSpeechRecognitionResult:(WMSSpeechRecognitionResult*)result {
-	
-	// the recognized phrase from what the user said
+- (void)setSpeechRecognitionLabelsWithSpeechRecognitionResult:(WMSSpeechRecognitionResult*)result
+{
+	// The recognized phrase from what the user said
 	NSString* destination = result.semanticInterpretation.properties[@"destination"][0];
 
-	// what the user said
+	// What the user said
 	NSString* spokenText = result.text;
 
-	// was the voice command actually spoken or typed in
+	// Was the voice command actually spoken or typed in
 	NSString* commandMode = result.semanticInterpretation.properties[@"commandMode"][0];
 
-	// the command name of the speech recognition result
+	// The command name of the speech recognition result
 	NSString* voiceCommandName = result.rulePath[0];
 
-	// set labels
+	// Set labels
 	[self semanticInterpretation:destination];
 	[self textSpoken:spokenText];
 	[self launchedBy:commandMode];

--- a/Scenarios/Cortana/CortanaSample/ViewController.m
+++ b/Scenarios/Cortana/CortanaSample/ViewController.m
@@ -1,0 +1,203 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+//////////////////////////////////////
+// WinObjC Sample - Cortana    ///////
+// github.com/Microsoft/WinObjC //////
+//////////////////////////////////////
+
+#import "ViewController.h"
+
+#ifdef WINOBJC
+#import <UWP/WindowsUINotifications.h>
+#import <UWP/WindowsDataXmlDom.h>
+#import <UWP/WindowsApplicationModelVoiceCommands.h>
+#endif
+
+@interface ViewController ()
+
+@property UILabel *demoTitle;
+@property UILabel *demoInfo;
+@property UILabel *labelVoiceCommand;
+@property UILabel *labelTextSpoken;
+@property UILabel *labelDestination;
+@property UILabel *labelCommandMode;
+
+@end
+
+@implementation ViewController
+
+// WinObjC example app constants
+static NSString * kTitleString = @"Cortana Sample";
+static NSString * kInfoString = @"This WinObjC sample project demonstrates how to interact with Cortana using Objective-C. The below labels will be updated with the command, spoken text, phrase and how the app was activated with. When launched using Cortana.";
+static NSString * kLabelVoiceCommandInitialText = @"VOICECOMMAND";
+static NSString * kLabelTextSpokenInitialText = @"TEXTSPOKEN";
+static NSString * kLabelDestinationInitialText = @"DESTINATION";
+static NSString * klabelCommandModeText = @"COMMANDMODE";
+
+- (void) viewDidLoad
+{
+    [super viewDidLoad];
+    
+    // Set up the demo title label
+    self.demoTitle = [UILabel new];
+    self.demoTitle.text = [NSString stringWithFormat:@"WinObjC: %@", kTitleString];
+    self.demoTitle.font = [UIFont boldSystemFontOfSize:[UIFont labelFontSize]];
+    self.demoTitle.textAlignment = NSTextAlignmentCenter;
+    self.demoTitle.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    // Set up the demo info label
+    self.demoInfo = [UILabel new];
+    self.demoInfo.text = kInfoString;
+    self.demoInfo.font = [UIFont systemFontOfSize:[UIFont systemFontSize]];
+    self.demoInfo.numberOfLines = 0;
+    self.demoInfo.lineBreakMode = NSLineBreakByWordWrapping;
+    self.demoInfo.textAlignment = NSTextAlignmentCenter;
+    self.demoInfo.translatesAutoresizingMaskIntoConstraints = NO;
+        
+    // Set up the labels
+	self.labelVoiceCommand = [UILabel new];
+    self.labelVoiceCommand.text = kLabelVoiceCommandInitialText;
+    self.labelVoiceCommand.font = [UIFont systemFontOfSize:[UIFont smallSystemFontSize]];
+    self.labelVoiceCommand.numberOfLines = 0;
+    self.labelVoiceCommand.lineBreakMode = NSLineBreakByWordWrapping;
+    self.labelVoiceCommand.textAlignment = NSTextAlignmentCenter;
+    self.labelVoiceCommand.translatesAutoresizingMaskIntoConstraints = NO;
+
+	self.labelTextSpoken = [UILabel new];
+    self.labelTextSpoken.text = kLabelTextSpokenInitialText;
+    self.labelTextSpoken.font = [UIFont systemFontOfSize:[UIFont smallSystemFontSize]];
+    self.labelTextSpoken.numberOfLines = 0;
+    self.labelTextSpoken.lineBreakMode = NSLineBreakByWordWrapping;
+    self.labelTextSpoken.textAlignment = NSTextAlignmentCenter;
+    self.labelTextSpoken.translatesAutoresizingMaskIntoConstraints = NO;
+
+    self.labelDestination = [UILabel new];
+    self.labelDestination.text = kLabelDestinationInitialText;
+    self.labelDestination.font = [UIFont systemFontOfSize:[UIFont smallSystemFontSize]];
+    self.labelDestination.numberOfLines = 0;
+    self.labelDestination.lineBreakMode = NSLineBreakByWordWrapping;
+    self.labelDestination.textAlignment = NSTextAlignmentCenter;
+    self.labelDestination.translatesAutoresizingMaskIntoConstraints = NO;
+
+	self.labelCommandMode = [UILabel new];
+    self.labelCommandMode.text = klabelCommandModeText;
+    self.labelCommandMode.font = [UIFont systemFontOfSize:[UIFont smallSystemFontSize]];
+    self.labelCommandMode.numberOfLines = 0;
+    self.labelCommandMode.lineBreakMode = NSLineBreakByWordWrapping;
+    self.labelCommandMode.textAlignment = NSTextAlignmentCenter;
+    self.labelCommandMode.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    [self.view addSubview:self.demoTitle];
+    [self.view addSubview:self.demoInfo];
+    [self.view addSubview:self.labelVoiceCommand];
+	[self.view addSubview:self.labelTextSpoken];
+    [self.view addSubview:self.labelDestination];
+	[self.view addSubview:self.labelCommandMode];
+    
+    // Layout constraints
+    NSDictionary *metrics = @{ @"pad": @80.0, @"margin": @40, @"demoInfoHeight": @120 };
+    NSDictionary *views = @{ @"title"				: self.demoTitle,
+                             @"info"				: self.demoInfo,
+							 @"voiceCommandLabel"	: self.labelVoiceCommand,
+                             @"textSpokenLabel"		: self.labelTextSpoken,
+                             @"destinationLabel"	: self.labelDestination,
+							 @"commandModeLabel"	: self.labelCommandMode
+                            };
+    
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[title]-|"
+                                                                      options:0
+                                                                      metrics:metrics
+                                                                        views:views]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[info]-|"
+                                                                      options:0
+                                                                      metrics:metrics
+                                                                        views:views]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[voiceCommandLabel]-|"
+                                                                      options:0
+                                                                      metrics:metrics
+                                                                        views:views]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[textSpokenLabel]-|"
+                                                                      options:0
+                                                                      metrics:metrics
+                                                                        views:views]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[destinationLabel]-|"
+                                                                      options:0
+                                                                      metrics:metrics
+                                                                        views:views]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[commandModeLabel]-|"
+                                                                      options:0
+                                                                      metrics:metrics
+                                                                        views:views]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-pad-[title]-[info(demoInfoHeight)]-margin-[voiceCommandLabel]-[textSpokenLabel]-[destinationLabel]-[commandModeLabel]"
+                                                                      options:0
+                                                                      metrics:metrics
+                                                                        views:views]];
+
+#ifdef WINOBJC
+    [[UIApplication sharedApplication] setStatusBarHidden:YES]; // Deprecated in iOS
+#endif
+}
+
+- (BOOL) prefersStatusBarHidden
+{
+    return YES;
+}
+
+- (void)voiceCommand: (NSString*)text{
+	kLabelVoiceCommandInitialText = text;
+    self.labelVoiceCommand.text = kLabelVoiceCommandInitialText;
+}
+
+- (void)textSpoken: (NSString*)text{
+	kLabelTextSpokenInitialText = text;
+    self.labelTextSpoken.text = kLabelTextSpokenInitialText;
+}
+
+- (void)launchedBy: (NSString*)text{
+	klabelCommandModeText = text;
+	self.labelCommandMode.text = klabelCommandModeText;
+}
+
+- (void)semanticInterpretation: (NSString*)text{
+	kLabelDestinationInitialText = text;
+	self.labelDestination.text = kLabelDestinationInitialText;
+}
+
+#ifdef WINOBJC
+- (void)setSpeechRecognitionLabelsWithSpeechRecognitionResult:(WMSSpeechRecognitionResult*)result {
+	
+	// the recognized phrase from what the user said
+	NSString* destination = result.semanticInterpretation.properties[@"destination"][0];
+
+	// what the user said
+	NSString* spokenText = result.text;
+
+	// was the voice command actually spoken or typed in
+	NSString* commandMode = result.semanticInterpretation.properties[@"commandMode"][0];
+
+	// the command name of the speech recognition result
+	NSString* voiceCommandName = result.rulePath[0];
+
+	// set labels
+	[self semanticInterpretation:destination];
+	[self textSpoken:spokenText];
+	[self launchedBy:commandMode];
+	[self voiceCommand:voiceCommandName];
+}
+#endif
+
+@end

--- a/Scenarios/Cortana/CortanaSample/main.m
+++ b/Scenarios/Cortana/CortanaSample/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  CortanaSample
+//
+//  Created by Phil Nachreiner on 5/13/16.
+//  Copyright © 2016 Microsoft. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/Scenarios/Cortana/README.md
+++ b/Scenarios/Cortana/README.md
@@ -4,9 +4,8 @@ Cortana offers a robust and comprehensive extensibility framework that enables y
 
 These are the basic steps to add voice command functionality and integrate Cortana with your app using speech or keyboard input:
 
-1.  Create a Voice Command Definition (VCD) file. This is an XML document that defines all the spoken commands that the user can say to initiate actions or invoke commands when activating your app. [VCD elements and attributes v1.2](https://msdn.microsoft.com/library/windows/apps/dn706593).
-2.  Register the command sets in the VCD file when the app is launched.
-3.  Handle the activation-by-voice-command.
+1. **Create a Voice Command Definition (VCD) file and register it when the app is launched.** The VCD file is an XML document that defines all the spoken commands that the user can say to initiate actions or invoke commands when activating your app. For more information, see [VCD elements and attributes v1.2](https://msdn.microsoft.com/library/windows/apps/dn706593).
+2. **Handle the activation-by-voice command.** You may want to handle launch differently depending on the method by which a user launched your app.
 
 ## The Code
 
@@ -43,40 +42,41 @@ The code for incorporating Cortana functionality using Objective-C looks like th
 **AppDelegate.m**
 *Registers VCD file and handles the activation-by-voice command*
 ```Objective-C
-	- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-	#ifdef WINOBJC
-		WAPackage *package = [WAPackage current];
-		WSStorageFolder *installedLocation = package.installedLocation;
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#ifdef WINOBJC
+	WAPackage *package = [WAPackage current];
+	WSStorageFolder *installedLocation = package.installedLocation;
 
-		// Load VCD XML file describing voice commands from app installation location
-		[installedLocation getFileAsync:@"CortanaSampleCommands.xml"
-										success:^(WSStorageFile *storageFile) {
-											// install commands
-											[WAVVoiceCommandDefinitionManager installCommandDefinitionsFromStorageFileAsync:storageFile];
-										}
-										failure:^(NSError *error) {
-											NSLog(@"Failed to load commands file: %@", error);
-										}];
+	// Load VCD XML file describing voice commands from app installation location
+	[installedLocation getFileAsync:@"CortanaSampleCommands.xml"
+							success:^(WSStorageFile *storageFile) {
+								// Install commands
+								[WAVVoiceCommandDefinitionManager installCommandDefinitionsFromStorageFileAsync:storageFile];
+							}
+							failure:^(NSError *error) {
+								NSLog(@"Failed to load commands file: %@", error);
+							}];
 
-		// Handle activation-by-voice command
-		if (launchOptions != nil) {
-			// Check for the key containing WMSSpeechRecognitionResults
-			if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
-				WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
-				ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
-				[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
-			}
+	// Handle activation-by-voice command
+	if (launchOptions != nil) {
+		// Check for the key containing WMSSpeechRecognitionResults
+		if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
+			WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
+			ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
+			[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
 		}
-	#endif
-		return YES;
 	}
+#endif
+	return YES;
+}
 ```
 **ViewController.m**
 *Updates views using WMSSpeechRecognitionResult*
 ```Objective-C
 #ifdef WINOBJC
-- (void)setSpeechRecognitionLabelsWithSpeechRecognitionResult:(WMSSpeechRecognitionResult*)result {
-
+- (void)setSpeechRecognitionLabelsWithSpeechRecognitionResult:(WMSSpeechRecognitionResult*)result
+{
 	// The recognized phrase from what the user said
 	NSString* destination = result.semanticInterpretation.properties[@"destination"][0];
 
@@ -140,22 +140,23 @@ To include these frameworks – and make sure they’re only included when the 
 Next, we’ll extend the application delegate `application:didFinishLaunchingWithOptions` method to register the voice command set in the VCD XML file when the app is launched:
 
 ```Objective-C
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
 #ifdef WINOBJC
 	WAPackage *package = [WAPackage current];
 	WSStorageFolder *installedLocation = package.installedLocation;
 
 	// Load VCD XML file describing voice commands from app installation location
 	[installedLocation getFileAsync:@"CortanaSampleCommands.xml"
-									success:^(WSStorageFile *storageFile) {
-										// install commands
-										[WAVVoiceCommandDefinitionManager installCommandDefinitionsFromStorageFileAsync:storageFile];
-									}
-									failure:^(NSError *error) {
-										NSLog(@"Failed to load commands file: %@", error);
-									}];
+							success:^(WSStorageFile *storageFile) {
+								// Install commands
+								[WAVVoiceCommandDefinitionManager installCommandDefinitionsFromStorageFileAsync:storageFile];
+							}
+							failure:^(NSError *error) {
+								NSLog(@"Failed to load commands file: %@", error);
+							}];
 #endif
-  return YES;
+	return YES;
 }
 ```
 
@@ -167,47 +168,51 @@ You may want to handle app activation differently depending on how the user laun
 Update the *AppDelegate.m* method `application:didFinishLaunchingWithOptions` to handle the activation-by-voice command by checking the `LaunchOptions` dictionary for `UIApplicationLaunchOptionsVoiceCommandKey` and grabbing the `WMSSpeechRecognitionResult` value:
 
 ```Objective-C
-  - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  #ifdef WINOBJC
-  	[...]
-      if (launchOptions != nil) {
-  		// Check for the key containing WMSSpeechRecognitionResults
-  		if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
-  			WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
-  			ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
-  			[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
-  		}
-  	}
-  #endif
-  	return YES;
-  }
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#ifdef WINOBJC
+	[...]
+	// Handle activation-by-voice command
+	if (launchOptions != nil) {
+		// Check for the key containing WMSSpeechRecognitionResults
+		if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
+			WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
+			ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
+			[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
+		}
+	}
+#endif
+	return YES;
+}
 ```
 
 Add the new `application:didReceiveVoiceCommand` delegate method for responding to voice commands:
 
 ```Objective-C
-	#ifdef WINOBJC
-	// Called when a voice command is received.
-	- (void)application:(UIApplication *)application didReceiveVoiceCommand:(WMSSpeechRecognitionResult*)result {
-		ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
-		[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
-	}
-	#endif
+#ifdef WINOBJC
+// Called when a voice command is received
+- (void)application:(UIApplication *)application didReceiveVoiceCommand:(WMSSpeechRecognitionResult*)result
+{
+	ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
+	[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
+}
+#endif
 ```
 
 `application:willFinishLaunchingWithOptions` can also be updated to respond to voice commands as well:
 
 ```Objective-C
-	- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-		if(launchOptions != nil){
-	#ifdef WINOBJC
-			if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
-				// you could handle WMSSpeechRecognitionResult in here also
-			}
-	#endif
+- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+	if(launchOptions != nil){
+#ifdef WINOBJC
+		if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]) {
+			// You could handle WMSSpeechRecognitionResult in here also
 		}
-		return YES;
+#endif
 	}
+	return YES;
+}
 ```
 
 #### Update the UI to respond to users' voice commands

--- a/Scenarios/Cortana/README.md
+++ b/Scenarios/Cortana/README.md
@@ -1,8 +1,8 @@
 # Using Projections: Cortana
 
-Cortana offers a robust and comprehensive extensibility framework that enables you to seamlessly incorporate functionality from your app into the Cortana experience. Using voice commands, your app can be activated to the foreground and an action or command executed within the app.
+Cortana offers a robust and comprehensive extensibility framework that enables you to seamlessly incorporate functionality from your app into the Cortana experience. With Cortana, your app can be activated to the foreground and an action or command executed within the app using voice and typed commands.
 
-These are the basic steps to add voice-command functionality and integrate Cortana with your app using speech or keyboard input:
+These are the basic steps to add voice command functionality and integrate Cortana with your app using speech or keyboard input:
 
 1.  Create a Voice Command Definition (VCD) file. This is an XML document that defines all the spoken commands that the user can say to initiate actions or invoke commands when activating your app. [VCD elements and attributes v1.2](https://msdn.microsoft.com/library/windows/apps/dn706593).
 2.  Register the command sets in the VCD file when the app is launched.
@@ -11,7 +11,9 @@ These are the basic steps to add voice-command functionality and integrate Corta
 ## The Code
 
 The code for incorporating Cortana functionality using Objective-C looks like this:
-#### VCD XML File
+
+**VCD XML File**
+*Describes the commands and phrases to listen for*
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <VoiceCommands xmlns="http://schemas.microsoft.com/voicecommands/1.2">
@@ -38,15 +40,15 @@ The code for incorporating Cortana functionality using Objective-C looks like th
 </VoiceCommands>
 ```
 
-#### Register VCD File and handle the activation-by-voice-command
-
+**AppDelegate.m**
+*Registers VCD file and handles the activation-by-voice command*
 ```Objective-C
 	- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 	#ifdef WINOBJC
 		WAPackage *package = [WAPackage current];
 		WSStorageFolder *installedLocation = package.installedLocation;
 
-		// load command file from app installation location
+		// Load VCD XML file describing voice commands from app installation location
 		[installedLocation getFileAsync:@"CortanaSampleCommands.xml"
 										success:^(WSStorageFile *storageFile) {
 											// install commands
@@ -56,9 +58,9 @@ The code for incorporating Cortana functionality using Objective-C looks like th
 											NSLog(@"Failed to load commands file: %@", error);
 										}];
 
-		// handle the activation-by-voice-command
+		// Handle activation-by-voice command
 		if (launchOptions != nil) {
-			// check for the key containing WMSSpeechRecognitionResults
+			// Check for the key containing WMSSpeechRecognitionResults
 			if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
 				WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
 				ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
@@ -68,39 +70,40 @@ The code for incorporating Cortana functionality using Objective-C looks like th
 	#endif
 		return YES;
 	}
+```
+**ViewController.m**
+*Updates views using WMSSpeechRecognitionResult*
+```Objective-C
+#ifdef WINOBJC
+- (void)setSpeechRecognitionLabelsWithSpeechRecognitionResult:(WMSSpeechRecognitionResult*)result {
 
-	#ifdef WINOBJC
-	//
-	- (void)setSpeechRecognitionLabelsWithSpeechRecognitionResult:(WMSSpeechRecognitionResult*)result {
+	// The recognized phrase from what the user said
+	NSString* destination = result.semanticInterpretation.properties[@"destination"][0];
 
-		// the recognized phrase from what the user said
-		NSString* destination = result.semanticInterpretation.properties[@"destination"][0];
+	// What the user said
+	NSString* spokenText = result.text;
 
-		// what the user said
-		NSString* spokenText = result.text;
+	// Was the voice command actually spoken or typed in
+	NSString* commandMode = result.semanticInterpretation.properties[@"commandMode"][0];
 
-		// was the voice command actually spoken or typed in
-		NSString* commandMode = result.semanticInterpretation.properties[@"commandMode"][0];
-
-		// the command name of the speech recognition result
-		NSString* voiceCommandName = result.rulePath[0];
-	}
-	#endif
+	// The command name of the speech recognition result
+	NSString* voiceCommandName = result.rulePath[0];
+}
+#endif
 ```
 
 Read on for a complete explanation of how the above code works.
 
 ## Tutorial
 
-You can find the Cortana sample project under */Scenarios/Cortana/CortanaSample*. The project consists of a number of labels; when the a activation-by-voice-command is received, the labels are updated with the command, spoken text, phrase and how the app was activated with.
+You can find the Cortana sample project under */Scenarios/Cortana/CortanaSample*. The project consists of a number of labels; when the activation-by-voice command is received, the labels are updated with the command, spoken text, and method by which the app was activated.
 
-Let’s update this app to add Cortana functionality.
+Let’s walk through adding the Cortana functionality.
 
 ### Setting up
-First, open up the *CortanaSample* directory at your windows prompt.
-You will run the [VSImporter tool](https://github.com/Microsoft/WinObjC/wiki/Using-vsimporter) from the WinObjC SDK on the CortanaSample project to generate a Windows solution file (.sln).
+First, open up the *CortanaSample* directory at your Windows command prompt. Next, run the [vsimporter tool](https://github.com/Microsoft/WinObjC/wiki/Using-vsimporter) tool from the WinObjC SDK on the CortanaSample directory to generate a Visual Studio solution file (.sln).
 
-*Example:*
+*Running vsimporter:*
 ```
 c:\> cd "\winobjc-samples\Scenarios\Cortana\CortanaSample"
 c:\winobjc-samples\Scenarios\Cortana\CortanaSample> \winobjc-sdk\bin\vsimporter.exe
@@ -111,10 +114,10 @@ Generated c:\winobjc-samples\Scenarios\Cortana\CortanaSample\CortanaSample-WinSt
 
 Once you've generated the .sln file, open it in Visual Studio.
 
-### Add VCD XML file to *CortanaSample-WinStore10* project
-A sample VCD XML file has already been created and is present in the Xcode project, you'll need to add the VCD XML file to your project so it's present in the apps installed location
-In Visual Studio menu bar choose **Project**->**Add Existing Item**
-Add the VCD XML file (CortanaSampleCommands.xml) located in the original Xcode folder
+### Add the VCD XML file to *CortanaSample-WinStore10* project
+A sample VCD XML file is included in the CortanaSample Xcode project directory. After running *vsimporter*, you'll need to add the VCD XML file reference to your Visual Studio project manually.
+
+In the Visual Studio menu bar choose **Project** > **Add Existing Item**. Add the VCD XML file (*CortanaSampleCommands.xml*) located in the original Xcode project directory.
 
 ### Add UWP framework headers
 We need the public headers for the relevant UWP frameworks. In the extracted SDK (or your built SDK directory, if you’ve cloned [WinObjC from GitHub and built the project from source](https://github.com/Microsoft/WinObjC)), go to the [include\Platform\Universal Windows\UWP](https://github.com/Microsoft/WinObjC/tree/master/include/Platform/Universal Windows/UWP) directory and take a look at what you find. Each header file represents a different namespace within the [Windows Runtime APIs](https://msdn.microsoft.com/en-us/library/windows/apps/br211377.aspx). For our purposes, we will need APIs from:
@@ -125,6 +128,7 @@ We need the public headers for the relevant UWP frameworks. In the extracted SDK
 
 To include these frameworks – and make sure they’re only included when the code is being run on Windows – we’ll start by adding an #ifdef and two #import macros to the top of our application delegate implementation file:
 
+*AppDelegate.m*
 ```Objective-C
 #ifdef WINOBJC
 #import <UWP/WindowsApplicationModel.h>
@@ -133,14 +137,15 @@ To include these frameworks – and make sure they’re only included when the 
 #endif
 ```
 
-Next, we’ll extend the application delegate `application:didFinishLaunchingWithOptions` method with the code to register the command sets in the VCD XML file when the app is launched.
+Next, we’ll extend the application delegate `application:didFinishLaunchingWithOptions` method to register the voice command set in the VCD XML file when the app is launched:
 
 ```Objective-C
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 #ifdef WINOBJC
 	WAPackage *package = [WAPackage current];
 	WSStorageFolder *installedLocation = package.installedLocation;
 
-	// load command file from app installation location
+	// Load VCD XML file describing voice commands from app installation location
 	[installedLocation getFileAsync:@"CortanaSampleCommands.xml"
 									success:^(WSStorageFile *storageFile) {
 										// install commands
@@ -150,33 +155,23 @@ Next, we’ll extend the application delegate `application:didFinishLaunchingWit
 										NSLog(@"Failed to load commands file: %@", error);
 									}];
 #endif
+  return YES;
+}
 ```
 
 Now when you run the application the VCD XML file's commands will be registered with the system.
 
-### Handle the activation-by-voice-command.
-Depending on how the user launched your app (Start Menu, previously launched, Cortana), you'll need to handle the `WMSSpeechRecognitionResult` result in `application:didReceiveVoiceCommand`, `application:didFinishLaunchingWithOptions`, `application:willFinishLaunchingWithOptions`
+### Handle activation by voice command
+You may want to handle app activation differently depending on how the user launched your app (Start Menu, previously launched apps, or Cortana). To do so, you'll need to handle the `WMSSpeechRecognitionResult` result in `application:didReceiveVoiceCommand`, `application:didFinishLaunchingWithOptions`, `application:willFinishLaunchingWithOptions`.
 
-Update *AppDelegate.m* `application:didFinishLaunchingWithOptions` to handle the activation-by-voice-command by looking up in the `LaunchOptions` dictionary for `UIApplicationLaunchOptionsVoiceCommandKey` and grabbing the `WMSSpeechRecognitionResult` value.
+Update the *AppDelegate.m* method `application:didFinishLaunchingWithOptions` to handle the activation-by-voice command by checking the `LaunchOptions` dictionary for `UIApplicationLaunchOptionsVoiceCommandKey` and grabbing the `WMSSpeechRecognitionResult` value:
 
 ```Objective-C
   - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   #ifdef WINOBJC
-  	WAPackage *package = [WAPackage current];
-  	WSStorageFolder *installedLocation = package.installedLocation;
-
-  	// load command file from app installation location
-  	[installedLocation getFileAsync:@"CortanaSampleCommands.xml"
-  									success:^(WSStorageFile *storageFile) {
-  										// install commands
-  										[WAVVoiceCommandDefinitionManager installCommandDefinitionsFromStorageFileAsync:storageFile];
-  									}
-  									failure:^(NSError *error) {
-  										NSLog(@"Failed to load commands file: %@", error);
-  									}];
-
+  	[...]
       if (launchOptions != nil) {
-  		// check for the key containing WMSSpeechRecognitionResults
+  		// Check for the key containing WMSSpeechRecognitionResults
   		if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
   			WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
   			ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
@@ -188,7 +183,7 @@ Update *AppDelegate.m* `application:didFinishLaunchingWithOptions` to handle the
   }
 ```
 
-Add the new `application:didReceiveVoiceCommand` delegate for responding to voice commands.
+Add the new `application:didReceiveVoiceCommand` delegate method for responding to voice commands:
 
 ```Objective-C
 	#ifdef WINOBJC
@@ -200,7 +195,7 @@ Add the new `application:didReceiveVoiceCommand` delegate for responding to voic
 	#endif
 ```
 
-`application:willFinishLaunchingWithOptions` can also be updated to respond to voice commands also.
+`application:willFinishLaunchingWithOptions` can also be updated to respond to voice commands as well:
 
 ```Objective-C
 	- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
@@ -215,22 +210,22 @@ Add the new `application:didReceiveVoiceCommand` delegate for responding to voic
 	}
 ```
 
-#### Update the UI to respond to the users voice command.
-The *CortanaSample* contains code to display the results of voice commands in text labels in the UI.  You'll want to add your own functionality to respond to users voice commands.
+#### Update the UI to respond to users' voice commands
+The *CortanaSample* project contains code to display the results of voice commands in text labels.  You'll want to add your own functionality to respond to users' voice commands.
 
-That’s it! You’re done. Now, try asking Cortana to show your trip's.
+That’s it! You’re done. Now, try asking Cortana to show your trips.
 
-When Cortana is listening, here are some of the following voice commands.
-*  "Cortana Sample, show trip to London"
+When Cortana is listening, here are some of the voice commands that work in the sample:
+* "Cortana Sample, show trip to London"
 
-Infix and suffix forms are also supported.
-*  "Show trip to Rioin Cortana Sample"
+Infix and suffix forms are also supported:
+* "Show trip to Rioin Cortana Sample"
 * "Show my Cortana Sample trip to London"
 
 ## Additional Reading
-Want a deeper dive into everything a Cortana can do? Check out:
+Want a deeper dive into everything Cortana can do? Check out:
 - The [Cortana interactions in UWP apps](https://msdn.microsoft.com/windows/uwp/input-and-devices/cortana-interactions)
-- The iOS bridge [UWP header libraries](https://github.com/Microsoft/WinObjC/tree/master/include/Platform/Universal Windows/UWP) to find the exact API's you need.
-- The iOS bridge [DEV DESIGN Specification for Cortana Activation] (https://github.com/Microsoft/WinObjC/blob/develop/docs/Foundation/CortanaForegroundActivation.md) to learn more about how Cortana is exposed to apps.
+- The iOS bridge [UWP header libraries](https://github.com/Microsoft/WinObjC/tree/master/include/Platform/Universal Windows/UWP) to find the exact APIs you need.
+- The iOS bridge [Dev Design Specification for Cortana Activation] (https://github.com/Microsoft/WinObjC/blob/develop/docs/Foundation/CortanaForegroundActivation.md) to learn more about how Cortana is exposed to Objective-C apps.
 
 Microsoft also hosts an excellent [design guide to Cortana user experience](https://msdn.microsoft.com/en-us/library/windows/apps/xaml/dn974233.aspx) on MSDN.

--- a/Scenarios/Cortana/README.md
+++ b/Scenarios/Cortana/README.md
@@ -1,3 +1,213 @@
 # Using Projections: Cortana
 
-*Coming soon.*
+Cortana offers a robust and comprehensive extensibility framework that enables you to seamlessly incorporate functionality from your app into the Cortana experience. Using voice commands, your app can be activated to the foreground and an action or command executed within the app.
+
+These are the basic steps to add voice-command functionality and integrate Cortana with your app using speech or keyboard input: 
+1. Create a Voice Command Definition (VCD) file. This is an XML document that defines all the spoken commands that the user can say to initiate actions or invoke commands when activating your app. [VCD elements and attributes v1.2](https://msdn.microsoft.com/library/windows/apps/dn706593). 
+2. Register the command sets in the VCD file when the app is launched. 
+3. Handle the activation-by-voice-command.
+
+## The Code
+
+The code for incorporating Cortana functionality using Objective-C looks like this:
+```VCD XML document
+<?xml version="1.0" encoding="utf-8"?>
+<VoiceCommands xmlns="http://schemas.microsoft.com/voicecommands/1.2">
+  <CommandSet xml:lang="en-us" Name="CortanaSampleCommandSet_en-us">
+    <AppName>Cortana Sample</AppName>
+    <Example>Show trip to London</Example>
+
+    <Command Name="showTripToDestination">
+      <Example>Show trip to London</Example>
+      <ListenFor RequireAppName="BeforeOrAfterPhrase">show [my] trip to {destination}</ListenFor>
+      <ListenFor RequireAppName="ExplicitlySpecified">show [my] {builtin:AppName} trip to {destination}</ListenFor>
+      <Feedback>Showing trip to {destination}</Feedback>
+      <Navigate />
+    </Command>
+    <PhraseList Label="destination">
+      <Item>London</Item>
+      <Item>Long Island</Item>
+      <Item>Melbourne</Item>
+      <Item>North Dakota</Item>
+      <Item>Rio</Item>
+      <Item>Yosemite National Park</Item>
+    </PhraseList>
+  </CommandSet>
+</VoiceCommands>
+
+```Objective-C
+	// register VCD
+	- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+	#ifdef WINOBJC
+		WAPackage *package = [WAPackage current];
+		WSStorageFolder *installedLocation = package.installedLocation;
+
+		// load command file from app installation location
+		[installedLocation getFileAsync:@"CortanaSampleCommands.xml" 
+										success:^(WSStorageFile *storageFile) {
+											// install commands
+											[WAVVoiceCommandDefinitionManager installCommandDefinitionsFromStorageFileAsync:storageFile];
+										} 
+										failure:^(NSError *error) {
+											NSLog(@"Failed to load commands file: %@", error);
+										}];
+		
+		// handle the activation-by-voice-command
+		if (launchOptions != nil) {
+			// check for the key containing WMSSpeechRecognitionResults 
+			if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
+				WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
+				ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
+				[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
+			}
+		}
+	#endif
+		return YES;
+	}
+	
+	#ifdef WINOBJC
+	// 
+	- (void)setSpeechRecognitionLabelsWithSpeechRecognitionResult:(WMSSpeechRecognitionResult*)result {
+		
+		// the recognized phrase from what the user said
+		NSString* destination = result.semanticInterpretation.properties[@"destination"][0];
+
+		// what the user said
+		NSString* spokenText = result.text;
+
+		// was the voice command actually spoken or typed in
+		NSString* commandMode = result.semanticInterpretation.properties[@"commandMode"][0];
+
+		// the command name of the speech recognition result
+		NSString* voiceCommandName = result.rulePath[0];
+
+		...
+	}
+	#endif
+```
+
+Read on for a complete explanation of how the above code works.
+
+## Tutorial
+
+You can find the Cortana sample project under */Scenarios/Cortana/CortanaSample*. The project consists of a number of labels; when the a activation-by-voice-command is received, the labels are updated with the command, spoken text, phrase and how the app was activated with.
+
+Let’s update this app to send that information to the tile.
+
+### Setting up
+First, open up the *CortanaSample* directory at your windows prompt. 
+You will run the [VSImporter tool](https://github.com/Microsoft/WinObjC/wiki/Using-vsimporter) from the WinObjC SDK on the CortanaSample project to generate a Windows solution file (.sln).
+
+*Example:*
+```
+c:\> cd "\winobjc-samples\Scenarios\Cortana\CortanaSample"
+c:\winobjc-samples\Scenarios\Cortana\CortanaSample> \winobjc-sdk\bin\vsimporter.exe
+Generated c:\winobjc-samples\Scenarios\Cortana\CortanaSample\CortanaSample.vsimporter\CortanaSample-Headers-WinStore10\CortanaSample-Headers.vcxitems
+Generated c:\winobjc-samples\Scenarios\Cortana\CortanaSample\CortanaSample.vsimporter\LiveTileSampleSample-WinStore10\CortanaSample.vcxproj
+Generated c:\winobjc-samples\Scenarios\Cortana\CortanaSample\CortanaSample-WinStore10.sln
+
+Once you've generated the .sln file, open it in Visual Studio.
+
+We need the public headers for the relevant UWP frameworks. In the extracted SDK (or your built SDK directory, if you’ve cloned [WinObjC from GitHub and built the project from source](https://github.com/Microsoft/WinObjC)), go to the [include\Platform\Universal Windows\UWP](https://github.com/Microsoft/WinObjC/tree/master/include/Platform/Universal Windows/UWP) directory and take a look at what you find. Each header file represents a different namespace within the [Windows Runtime APIs](https://msdn.microsoft.com/en-us/library/windows/apps/br211377.aspx). For our purposes, we will need APIs from:
+
+-	[Windows.ApplicationModel](https://msdn.microsoft.com/en-us/library/windows/apps/windows.applicationmodel.aspx)
+-	[Windows.Storage](https://msdn.microsoft.com/en-us/library/windows/apps/windows.storage.aspx)
+-	[Windows.Media.SpeechRecognition](https://msdn.microsoft.com/en-us/library/windows/apps/windows.media.speechrecognition.aspx)
+
+To include these frameworks – and make sure they’re only included when the code is being run on Windows – we’ll start by adding an #ifdef and two #import macros to the top of our application delegate implementation file:
+
+```Objective-C
+#ifdef WINOBJC
+#import <UWP/WindowsApplicationModel.h>
+#import <UWP/WindowsStorage.h>
+#import <UWP/WindowsApplicationModelVoiceCommands.h>
+#endif
+```
+
+Next, we’ll extend the application delete :didFinishLaunchingWithOptions handler method with the code to register the command sets in the VCD file when the app is launched.
+
+```Objective-C
+#ifdef WINOBJC
+	WAPackage *package = [WAPackage current];
+	WSStorageFolder *installedLocation = package.installedLocation;
+
+	// load command file from app installation location
+	[installedLocation getFileAsync:@"CortanaSampleCommands.xml" 
+									success:^(WSStorageFile *storageFile) {
+										// install commands
+										[WAVVoiceCommandDefinitionManager installCommandDefinitionsFromStorageFileAsync:storageFile];
+									} 
+									failure:^(NSError *error) {
+										NSLog(@"Failed to load commands file: %@", error);
+									}];
+	...
+#endif
+```
+
+### Add the XML VCD file to the project
+For this sample a VCD file has already been created and is present in the Xcode project, you'll need to add the VCD file to the project so it's present in the apps installed location 
+Right click on the project CortanaSample (Universal Windows)
+Choose Add Existing Item
+Add the XML Document (CortanaSampleCommands.xml) located in the original Xcode folder
+
+Now when you run the application the XML VCD file's commands will be registered with the system
+```
+### Handle the activation-by-voice-command.
+Depending on how the app is launched: Start Menu, previously launched, Cortana, you'll need to handle the WMSSpeechRecognitionResult result in application:didReceiveVoiceCommand, application:didFinishLaunchingWithOptions, application:willFinishLaunchingWithOptions
+
+```Objective-C
+	- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+	#ifdef WINOBJC
+		...
+		if (launchOptions != nil) {
+			// check for the key containing WMSSpeechRecognitionResults 
+			if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
+				WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
+				ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
+				[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
+			}
+		}
+	#endif
+		return YES;
+	}
+
+	#ifdef WINOBJC
+	// Called when a voice command is received.
+	- (void)application:(UIApplication *)application didReceiveVoiceCommand:(WMSSpeechRecognitionResult*)result {
+		ViewController* viewController = (ViewController*) [[application keyWindow] rootViewController];
+		[viewController setSpeechRecognitionLabelsWithSpeechRecognitionResult:result];
+	}
+	#endif
+
+	- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+		if(launchOptions != nil){
+	#ifdef WINOBJC
+			if(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]){
+				// you could handle WMSSpeechRecognitionResult in here also
+			}
+	#endif
+		}
+		return YES;
+	}
+```
+
+TODO ADD MORE
+
+That’s it! You’re done. Now, try asking Cortana to show your trip's.
+
+## Additional Reading
+Want a deeper dive into everything a Cortana can do? Check out:
+- The [Cortana interactions in UWP apps](https://msdn.microsoft.com/windows/uwp/input-and-devices/cortana-interactions)
+- The iOS bridge [UWP header libraries](https://github.com/Microsoft/WinObjC/tree/master/include/Platform/Universal Windows/UWP) to find the exact API you need.
+
+Microsoft also hosts an excellent [design guide to Cortana user experience](https://msdn.microsoft.com/en-us/library/windows/apps/xaml/dn974233.aspx) on MSDN.
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Sample code for incorporating Cortana functionality using Objective-C.  This sample leverages the new UIApplicationLaunchOptionsVoiceCommandKey LaunchOptions key to retrieve voice commands during app activation.  Change also includes tutorial that walks through the code in the sample.
