### PR TITLE
Update toast notification from UI Thread

### DIFF
--- a/Scenarios/Toast Notifications/ToastNotificationSample/ToastNotificationsSample/ViewController.m
+++ b/Scenarios/Toast Notifications/ToastNotificationSample/ToastNotificationsSample/ViewController.m
@@ -263,17 +263,20 @@ static NSString * const kLabelInitialText = @"Press the button to generate a toa
     // Add the notification foreground activation event
     [notification addActivatedEvent:^void(WUNToastNotification * sender, RTObject * args)
     {
-    	// Cast the callback block args to their proper type
-    	WUNToastActivatedEventArgs* toastArgs = rt_dynamic_cast([WUNToastActivatedEventArgs class], args);
+		[[NSOperationQueue mainQueue] addOperationWithBlock:^{
+    		// Cast the callback block args to their proper type
+    		WUNToastActivatedEventArgs* toastArgs = rt_dynamic_cast([WUNToastActivatedEventArgs class], args);
     
-    	// Get the event info and args
-    	NSLog(@"Notification tag: %@", sender.tag);
-    	NSLog(@"Notification group: %@", sender.group);
-    	NSLog(@"Notification args: %@", toastArgs.arguments);
+    		// Get the event info and args
+    		NSLog(@"Notification tag: %@", sender.tag);
+    		NSLog(@"Notification group: %@", sender.group);
+    		NSLog(@"Notification args: %@", toastArgs.arguments);
     
-    	// Update button label
-    	NSString *timeDateString = [self getTimeDateString];
-    	self.actionNotificationLabel.text = [NSString stringWithFormat:@"App activated by toast with tag %@ and group %@ at %@", sender.tag, sender.group, timeDateString];
+    		// Update button label
+    		NSString *timeDateString = [self getTimeDateString];
+		
+			self.actionNotificationLabel.text = [NSString stringWithFormat:@"App activated by toast with tag %@ and group %@ at %@", sender.tag, sender.group, timeDateString];
+		}];
     }];
     
     // Provide tag and group to the notification


### PR DESCRIPTION
Update Toast Notification sample's callback label from UI thread.

Windows does not guarantee that the callback from a notification will run on the UI thread.

https://github.com/Microsoft/Windows-universal-samples/blob/master/Samples/Notifications/cs/Notifications/ScenarioPages/Toasts/ActivationTypes/ForegroundWithAppClosed/ScenarioElement.xaml.cs#L107 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc-samples/40)
<!-- Reviewable:end -->
